### PR TITLE
Fixes inconsistent encoding behavior.

### DIFF
--- a/ipfsapi/encoding.py
+++ b/ipfsapi/encoding.py
@@ -278,7 +278,7 @@ class Json(Encoding):
         """
         try:
             result = json.dumps(obj, sort_keys=True, indent=None,
-                                separators=(',', ':'))
+                                separators=(',', ':'), ensure_ascii=False)
             if isinstance(result, six.text_type):
                 return result.encode("utf-8")
             else:


### PR DESCRIPTION
Python encodes ASCII by default and escapes the unicode characters.
This fix enforces utf-8.